### PR TITLE
bump firefox maxVersion to 40

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -20,7 +20,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>4.0</em:minVersion>
-        <em:maxVersion>39.*</em:maxVersion>
+        <em:maxVersion>40.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 

--- a/install.rdf
+++ b/install.rdf
@@ -20,7 +20,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>4.0</em:minVersion>
-        <em:maxVersion>40.*</em:maxVersion>
+        <em:maxVersion>50.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 
@@ -29,7 +29,7 @@
       <Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
         <em:minVersion>5.0</em:minVersion>
-        <em:maxVersion>39.*</em:maxVersion>
+        <em:maxVersion>50.*</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
Hi,
firefox 40 is now available so the maxVersion needs a bump. It will probably need a bigger bump soon.
I didn't test it and I don't if some other metadatas (e.g., id) need to be changed too.
